### PR TITLE
feat: update README, LICENSE, add Contrib, CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+ospo@digg.se.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,0 +1,137 @@
+= Contributing
+:toc:
+
+Welcome! We are excited that you are interested in contributing to our project!
+However, there are some things you might need to know, so please browse the following:
+
+[[ways-to-contribute]]
+== Ways to Contribute
+
+There are multiple ways of getting involved:
+
+As a new contributor, you are in an excellent position to give us feedback to our project. For example, you could:
+
+* Fix or report a bug.
+* Suggest enhancements to code, tests and documentation.
+* Report/fix problems found during installing or developer environments.
+* Add suggestions for something else that is missing. 
+
+[[community-guideline]]
+== Community Guildeline
+
+Be nice and respectful to each other.
+
+We follow the link:CODE_OF_CONDUCT.md[Contributor Covenant Code Of Conduct].
+
+[[file-issue]]
+== File an Issue
+
+Please check briefly if there already exists an Issue with your topic.
+If so, you can just add a comment to that with your information instead of creating a new Issue.
+
+=== Report a bug
+
+To report bugs is a good and easy way to contribute.
+
+To do this, open an Issue that summarizes the bug and set the label to "bug".
+
+=== Suggest a feature
+
+To request a new feature you should and summarize the desired functionality and its use case.
+Set the Issue label to "feature" or "enhancement".
+
+
+[[contribute-code]]
+== Contribute Code, Documentation and more
+
+You want to contribute code, documentation or 'your fantastic thing x'. 
+Great, however, there are some practical points to check to make sure that everything runs as smoothly as possible.
+
+* It is always best to discuss your plans beforehand, to ensure that your contribution is in line with our goals.
+* Check the list of open Issues. Either assign an existing issue to yourself, or create a new one that you would like to work on, and discuss your ideas and use cases.
+* Follow the projects' convention and style regarding test, code and documentation, commit style etc.
+* The project can decide to decline a contribution not following the general project guidelines, or deemed to not fit into the general project goal/architecture.
+* Make sure you have an understanding of the link:#pull-request[Pull Request Lifecycle]
+* You agree to that in general, all contributions to this project will be released under the **inbound=outbound** norm, that is,
+ they are submitted under the same terms as the project licenses. In a more formal way - 'Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of the projects License, without any additional terms or conditions.'
+* link:#signoff-and-signing-a-commit[Sign your commits].
+
+[[pull-request]]
+== Pull Request Lifecycle
+
+Generally speaking, you should fork this repository, make changes in your
+own fork, and then submit a pull-request. 
+This workflow is common, maybe even expected if nothing else mentioned, and is called the https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models#fork-and-pull-model[Fork-and-Pull model]
+
+A practical example of such a workflow could be:
+
+1 Fork the repository.
+2 Create a topic branch from your forks main/master branch, i.e. myfeaturebranch
+3 Push your changes to the topic branch (in your fork) of the repository, i.e myfeaturebranch.
+4 Open a new pull request to main project.
+5 Project maintainers might comment and give feedback on your Pull Request.
+
+[[commit-guideline]]
+== Commit Guidelines
+
+=== DCO - Signoff and Signing a Commit
+
+NOTE: Signoff and signing: Two similar terms for two different things + 
+**_A Signoff assures to the project that you have the right to contribute your content_** + 
+**_A Sign assures that the commit came from you_**
+
+==== Signoff (DCO agree)
+
+A standard practice in the Open Source communities is the https://developercertificate.org/[DCO - Developer Certificate of Origin]. 
+It is a lightweight way for a project for extra assurance that the contributor wrote and/or have the right to submit the contribution.
+
+It is supersimple!
+
+As part of filing a pull request you agree to the DCO, by just adding a *sign off*  to your commit.
+Technically, this is done by supplying the `-s`/`--signoff` flag:
+
+Example:
+[source,shell]
+----
+$ git commit --signoff -m 'fix: add fix for superbug x'
+----
+
+==== Sign
+
+Optionally, you can also sign the commit with `-S`/`--gpg-sign`. 
+Besides extra trust, it also gives your commit a nice verified button in the UI on most Git platforms and further assures trust.
+It requires that you have a GPG keypair set up, see https://docs.github.com/en/github/authenticating-to-github/signing-commits[Sign commit on GitHub with GPG key]
+
+[source,shell]
+----
+`$ git commit --signoff --gpg-sign -m "fix: add fix for the bug"`
+----
+
+=== Commit Standard
+
+Aim for a clear human readable commit history:
+
+* **_Does the project have a defined commit message practice, please follow that_**. 
+* Make sure you link:#dco-signoff-and-signing-a-commitsign-off[Sign-Off] your commits.
+* In general
+    ** Make commits of logical units.
+    ** Your commit messages should tell a human reader what will it do when the commit is applied.
+    ** If the project does not have standard for commits, you might want to consider https://www.conventionalcommits.org[Conventional Commit standard].
+    ** Make your commit message/s easily human readable in a expected way: +
+        *** A Conventional Commit example: +
+        _fix: add a null pointer check to MyMethod parameter_ +
+        Would be read as 'When this fix is applied it will add a null pointer check to MyMethod parameter'
+
+[[security]]
+== Reporting security issues
+
+If you discover a security issue, please bring it to our attention.
+
+If the vulnerability is a widely known issue, such as one publically known from https://nvd.nist.gov/vuln/search[NIST/NVD]
+it might be okay to file an public Issue.
+
+However, if any uncertainty around this, please **DO NOT** file a public issue, see link:SECURITY.md[Security information] for how to handle this. 
+
+Security reports are *greatly* appreciated.
+
+**_Happy contributing!_**

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 intunioab
+Copyright (c) 2022 Havs- och vattenmyndigheten
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,66 @@
 
 This Outlook add-in adds a randomly generated Jitsi link to an appointment (while in the appointment creation window). It was built based on the Yeoman generator, as described in the this [guide](https://learn.microsoft.com/en-us/office/dev/add-ins/quickstarts/outlook-quickstart?tabs=yeomangenerator).
 
-![Example image of the generated Jitsi signature](screenshot.png "Example image of the generated Jitsi signature")
+![Photo: Jitsi Outlook plugin example / HaV / CC0](screenshot.png)
+<figcaption>Jitsi Outlook plugin example / HaV / CC0</figcaption>
+
+---
+
+## Table of Contents
+
+- [Installation and Requirements](#installation-and-requirements)
+- [Known Issues](#known-issues)
+- [Contributing](#contributing)
+- [Development](#development)
+- [License](#license)
+- [Maintainers](#maintainers)
+
+
+## Installation and Requirements
+
+### **Publishing the add-in**
+
+See [Development](#development) for how you can run and test the project locally.
+
+This project does not provide a hosting or publishing recommendation, that is entirely up to the individual(s) using it. Microsoft provides a comprehensive publishing guide and provides different options in the following [link](https://learn.microsoft.com/en-us/office/dev/add-ins/publish/publish).
+
+## Known issues
+
+This project is a stripped down version with basic functionality. There are ideas and possible plans for the future.
+
+## Contributing
+
+Please see the [CONTRIBUTING](CONTRIBUTING.adoc) guide.
+
+## Development
+
+## **Installing the add-in on your Outlook**
+
+For development, The add-in needs to be added to the relevant Outlook environment. The methods to do this are described in this section.
+
+### **Adding the add-in to the Outlook taskbar**
+
+The `manifest.xml` can be added as an add-in manually, through Outlooks add-in portal:
+
+1. Open Outlook
+2. Click the "..." button on the toolbar
+3. Select "Get Add-ins"
+4. Click on the "My add-ins" alternative on the left side menu
+5. Click on the "Add a custom add-in" dropdown in the bottom section
+6. Select the relevant alternative for where your manifest file is stored
+7. Add the `manifest.xml` file and let it validate and load
+
+When it has finished loading the add-in should be visible in the toolbar whenever you have the event organizer window open. I.e. when you are trying to organize and invite people to meeting.
+
+### **Running the development server locally**
+
+You can run and test the add-in code by running the following npm command:
+
+```
+npm run dev-server
+```
+
+This will start the local development server on port 3000. If the aforementioned `manifest.xml` variables have been set to your local machine you will be able to run the add-in locally.
 
 ## **Configuration**
 
@@ -47,34 +106,15 @@ Thereafter, all the dependencies need to be installed:
 npm install
 ```
 
-## **Installing the add-in on your Outlook**
+----
 
-The add-in needs to be added to the relevant Outlook environment. The methods to do this are described in this section.
+## License
 
-### **Adding the add-in to the Outlook tasbar**
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
 
-The `manifest.xml` can be added as an add-in manually, through Outlooks add-in portal:
 
-1. Open Outlook
-2. Click the "..." button on the toolbar
-3. Select "Get Add-ins"
-4. Click on the "My add-ins" alternative on the left side menu
-5. Click on the "Add a custom add-in" dropdown in the bottom section
-6. Select the relevant alternative for where your manifest file is stored
-7. Add the `manifest.xml` file and let it validate and load
+----
 
-When it has finished loading the add-in should be visible in the toolbar whenever you have the event organizer window open. I.e. when you are trying to organize and invite people to meeting.
+## Maintainers
 
-### **Running the development server locally**
-
-You can run and test the add-in code by running the following npm command:
-
-```
-npm run dev-server
-```
-
-This will start the local development server on port 3000. If the aforementioned `manifest.xml` variables have been set to your local machine you will be able to run the add-in locally.
-
-### **Publishing the add-in**
-
-This project does not provide a hosting or publishing recommendation, this is entirely up to the individual(s) using it. Microsoft provides a comprehensive publishing guide and provides different options in the following [link](https://learn.microsoft.com/en-us/office/dev/add-ins/publish/publish).
+[The maintainer/s](INSERT_MAINTAINTERS_HERE)  


### PR DESCRIPTION
This PR improves the overall FOSS friendliness of the project. It improves the README structure,
corrects copyright in LICENSE, adds a general Contribution and a standard code of conduct.
The code of conduct  uses the well used
Contributor Covenant, https://www.contributor-covenant.org/. The CONTRIBUTING is based on a template taken from Digg's Open Source Guild, and should been seen as
a help base, that with time, can be adjusted to fit the project better, if needed.

Signed-off-by: Josef Andersson <josef.andersson@digg.se>