### PR TITLE
fix language strings in manifest so that translations are properly used

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -6,8 +6,8 @@
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="Jitsi"/>
   <Description DefaultValue="A Jitsi Add-in to easily add a Jitsi meeting instance to an appointment.">
-    <Override Locale="se" Value="En Jitsi Add-in som gör det enkelt att tilldela ett Jitsi-möte till din mötesinbjudan." />
-    <Override Locale="de" Value="Ein Jitsi-Add-In zum einfachen Hinzufügen einer Jitsi-Meeting-Instanz zu einem Termin." />
+    <Override Locale="sv_SE" Value="En Jitsi Add-in som gör det enkelt att tilldela ett Jitsi-möte till din mötesinbjudan." />
+    <Override Locale="de_DE" Value="Ein Jitsi-Add-In zum einfachen Hinzufügen einer Jitsi-Meeting-Instanz zu einem Termin." />
   </Description>
   <IconUrl DefaultValue="{PROJECT_BASE_URL}/assets/icon-64.png"/> 
   <HighResolutionIconUrl DefaultValue="{PROJECT_BASE_URL}/assets/logo-filled.png"/>
@@ -80,18 +80,18 @@
     <bt:ShortStrings>
         <bt:String id="Label" DefaultValue="Jitsi"/>
         <bt:String id="FunctionButton.Label" DefaultValue="Create Jitsi link">
-            <bt:Override Locale="se" Value="Skapa Jitsi-länk" />
-            <bt:Override Locale="de" Value="Jitsi-Link erstellen" />
+            <bt:Override Locale="sv_SE" Value="Skapa Jitsi-länk" />
+            <bt:Override Locale="de_DE" Value="Jitsi-Link erstellen" />
         </bt:String>
         <bt:String id="FunctionButton.Title" DefaultValue="Create Jitsi link">
-            <bt:Override Locale="se" Value="Skapa Jitsi-länk" />
-            <bt:Override Locale="de" Value="Jitsi-Link erstellen" />
+            <bt:Override Locale="sv_SE" Value="Skapa Jitsi-länk" />
+            <bt:Override Locale="de_DE" Value="Jitsi-Link erstellen" />
         </bt:String>
     </bt:ShortStrings>
     <bt:LongStrings>
         <bt:String id="FunctionButton.Tooltip" DefaultValue="Creates and pastes a Jitsi link into your meeting invite.">
-            <bt:Override Locale="se" Value="Skapar och klistrar in en Jitsi-länk i din mötesinbjudan." />
-            <bt:Override Locale="de" Value="Erstellt einen Jitsi-Link und fügt ihn in Ihre Besprechungseinladung ein." />
+            <bt:Override Locale="sv_SE" Value="Skapar och klistrar in en Jitsi-länk i din mötesinbjudan." />
+            <bt:Override Locale="de_DE" Value="Erstellt einen Jitsi-Link und fügt ihn in Ihre Besprechungseinladung ein." />
         </bt:String>
     </bt:LongStrings>
     </Resources>


### PR DESCRIPTION
# Pull Request Template

## Description

This fixes locale selection in the plugin. 

Fixes #16 

## Checklist

- [x] My contributions and commit messages follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] The Pull Request has an informative and human-readable title
- [x] Changes are limited to a single goal (avoid scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
