### PR TITLE
36: Add a REUSE compliance badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Unit Tests](https://github.com/diggsweden/jitsi-outlook/actions/workflows/webpack.yml/badge.svg)](https://github.com/diggsweden/jitsi-outlook/actions/workflows/webpack.yml)
 [![Standard commitment](https://github.com/publiccodenet/standard/blob/develop/assets/standard-for-public-code-commitment.svg)](https://github.com/diggsweden/jitsi-outlook/blob/main/CONTRIBUTING.adoc#standard-for-public-code)
+[![REUSE status](https://api.reuse.software/badge/github.com/diggsweden/jitsi-outlook)](https://api.reuse.software/info/github.com/diggsweden/jitsi-outlook)
 
 The purpose of this plug-in is to simplify the process of adding video conference links to meeting bookings. It is designed for users who value and require simplicity to complete their tasks quickly and intuitively. Therefore, it is important to preserve this simplicity as new features are added. Any additional contributions to the software must be designed in a way that does not interfere with or complicate the core functionality of booking a regular meeting with just one click.
 


### PR DESCRIPTION
# Description

The project uses the REUSE standard for license compliance, and this badge shows it nicely. It goes well along with the other existing badges.
Fixes #36 

## Checklist

- [x] My contributions and commit messages follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes
- [x] The Pull Request has an informative and human-readable title
- [x] Changes are limited to a single goal (avoid scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
