### PR TITLE
Add Dutch to localisation

### DIFF
--- a/src/localization.ts
+++ b/src/localization.ts
@@ -20,6 +20,11 @@ const getLocalizedStrings = (): LocalizedStrings => {
       connectToMeeting: "Verbinden",
       linkToMeeting: "Link zum Treffen",
     };
+  } else if (/nl/.test(myLanguage)) {
+    return {
+      connectToMeeting: "Verbinden met vergadering",
+      linkToMeeting: "Link naar vergadering",
+    };
   } else {
     // Default to english
     return {


### PR DESCRIPTION
I've taken the translation of 'meeting' from Jitsi.

I am contributing on behalf of the Staat der Nederlanden (State of the Netherlands) and it is contributed to the project without . I hereby sign of on that. I don't know how to add the sign-off in GitHub web interface.