### PR TITLE
41: Added support for configuring font family

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ All of the properties listed below can also be added to enable/disable any extra
 | --------------------- | -------- | --------------------------------------------------------------------------------- |
 | `baseUrl`             | string   | Base url to your Jitsi instance.                                                  |
 | `additionalText`      | string   | This text will show up at the bottom of the email signature.                      |
+| `fontFamily`          | string   | The font family used for for the signature text (defaulting to Arial)             |
 | `startWithAudioMuted` | boolean  | This forces the mic to be muted for every person entering the meeting.            |
 | `startWithVideoMuted` | boolean  | This forces the camera to be disabled for every person entering the meeting.      |
 | `disableInitialGUM`   | boolean  | Skips the initial permission check and configuration screen (GUM = getUserMedia). |

--- a/__tests__/DOMHelper.test.ts
+++ b/__tests__/DOMHelper.test.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import getLocalizedStrings from "../src/localization";
-import Config from "../src/models/Config";
+import Config, { defaultFontFamily } from "../src/models/Config";
 import { bodyHasJitsiLink, getJitsiLinkDiv, overwriteJitsiLinkDiv } from "../src/utils/DOMHelper";
 import * as URLHelper from "../src/utils/URLHelper";
 
@@ -42,6 +42,25 @@ describe("getJitsiLinkDOM", () => {
     const jitsiLinkDOM = getJitsiLinkDiv(jitsiUrl, config);
 
     expect(jitsiLinkDOM).not.toContain("additionalText");
+  });
+
+  it("should include the specified font if fontFamily is provided in config", () => {
+    const config: Config = {
+      fontFamily: "Times New Roman",
+    };
+    const jitsiUrl = URLHelper.getJitsiUrl(config);
+    const jitsiLinkDOM = getJitsiLinkDiv(jitsiUrl, config);
+
+    expect(jitsiLinkDOM).toContain(config.fontFamily);
+    expect(jitsiLinkDOM).not.toContain(defaultFontFamily);
+  });
+
+  it("should include the default font if fontFamily is not provided in config", () => {
+    const config: Config = {};
+    const jitsiUrl = URLHelper.getJitsiUrl(config);
+    const jitsiLinkDOM = getJitsiLinkDiv(jitsiUrl, config);
+
+    expect(jitsiLinkDOM).toContain(defaultFontFamily);
   });
 });
 

--- a/src/models/Config.ts
+++ b/src/models/Config.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 export const defaultMeetJitsiUrl = "https://meet.jit.si/";
+export const defaultFontFamily = "Arial";
 
 interface Config {
   baseUrl?: string;
@@ -11,6 +12,7 @@ interface Config {
     startWithAudioMuted?: boolean;
     startWithVideoMuted?: boolean;
   };
+  fontFamily?: string;
 }
 
 export default Config;

--- a/src/utils/DOMHelper.ts
+++ b/src/utils/DOMHelper.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import getLocalizedStrings from "../localization";
-import Config, { defaultMeetJitsiUrl } from "../models/Config";
+import Config, { defaultFontFamily, defaultMeetJitsiUrl } from "../models/Config";
 import { videoCameraURI } from "./IconHelper";
 import { getJitsiUrl } from "./URLHelper";
 
@@ -46,9 +46,10 @@ export const getJitsiLinkDiv = (jitsiUrl: string, config: Config): string => {
   const localizedStrings = getLocalizedStrings();
 
   const tdStyles = "padding-right: 10px; vertical-align: middle; background-color: transparent;";
+  const fontFamily = config.fontFamily ?? defaultFontFamily;
 
   return `
-    <div id="${DIV_ID_JITSI}" style="font-family: 'Arial';">
+    <div id="${DIV_ID_JITSI}" style="font-family: '${fontFamily}';">
         <span style="font-size: 14px; font-weight: 700;">
             ${localizedStrings.connectToMeeting}
         </span>


### PR DESCRIPTION
## Description

Adds support for configuring the font family of the signature text via `config.json`

Fixes #41 

## Checklist

- [x] My contributions and commit messages follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] The Pull Request has an informative and human-readable title
- [x] Changes are limited to a single goal (avoid scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] I confirm that I have read any Contribution guidelines (CONTRIBUTING)
- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the _Developer Certificate of Origin_, by adding a 'sign-off' to my commits
