### PR TITLE
Added subject to meeting link, this will show up in tab

### DIFF
--- a/__tests__/DOMHelper.test.ts
+++ b/__tests__/DOMHelper.test.ts
@@ -62,6 +62,46 @@ describe("getJitsiLinkDOM", () => {
 
     expect(jitsiLinkDOM).toContain(defaultFontFamily);
   });
+
+  it("should return a room containing subject line", () => {
+    const config: Config = {}
+    const testSubject: string = 'Test Meeting:;for +?"!new¤%€${€$[{]£$@£$£employee.,-.-...,,,,.-.-,.---.-,,.,._++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++';
+    const JitsiMeetingUrlProperties: string = URLHelper.getJitsiUrl(config, testSubject);
+    expect(JitsiMeetingUrlProperties).toContain("Test-Meeting-for-new-employee-");
+  });
+
+  it("should return a room containing subject line", () => {
+    const config: Config = {}
+    const testSubject: string = 'Möte angående:;nästa +?"!sprint¤%€${€$[{]£$@£$£.,-.-...,,,,.-.-,.---.-,,.,._++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++';
+    const JitsiMeetingUrlProperties: string = URLHelper.getJitsiUrl(config, testSubject);
+    expect(JitsiMeetingUrlProperties).toContain("Mote-angaende-nasta-sprint-");
+  });
+
+  it("should return a room containing only meeting id", () => {
+    const config: Config = {}
+    const testSubject: string = '';
+    const secureSubjectUrl: string = URLHelper.secureSubjectUrl(testSubject);
+    expect(secureSubjectUrl).toContain("");
+  });
+
+  it("should return a room containing only 30 characters", () => {
+    const config: Config = {}
+    const testSubject: string = 'Möte angående nästa sprint sen i fredags';
+    const secureSubjectUrl: string = URLHelper.secureSubjectUrl(testSubject);
+    expect(secureSubjectUrl).toHaveLength(31)
+  });
+
+  it("Should return empty string", () => {
+    const testSubject: string = ':; +?"!¤%€${€$[{]£$@£$£.,-.-...,,,,.-.-,.---.-,,.,._++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++';
+    const secureSubjectUrl: string = URLHelper.secureSubjectUrl(testSubject);
+    expect(secureSubjectUrl).toEqual("");
+  });
+
+  it("Should return -a-_ where - is collection of unsupported chars", () => {
+    const testSubject: string = ':a; +?"!¤%€${€$[{]£$@£$£.,-.-...,,,,.-.-,.---.-,,.,._++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++';
+    const secureSubjectUrl: string = URLHelper.secureSubjectUrl(testSubject);
+    expect(secureSubjectUrl).toEqual("-a-_");
+  });
 });
 
 describe("bodyHasJitsiLink", () => {

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -31,10 +31,12 @@ const addJitsiLink = (event: Office.AddinCommands.Event) => {
     }
 
     try {
-      const parser = new DOMParser();
-      const htmlDoc = parser.parseFromString(result.value, "text/html");
-      const bodyDOM = bodyHasJitsiLink(result.value, config) ? overwriteJitsiLinkDiv(htmlDoc, config) : combineBodyWithJitsiDiv(result.value, config);
-      setData(bodyDOM, event);
+      Office.context.mailbox.item.subject.getAsync((subject) => {
+        const parser = new DOMParser();
+        const htmlDoc = parser.parseFromString(result.value, "text/html");
+        const bodyDOM = bodyHasJitsiLink(result.value, config) ? overwriteJitsiLinkDiv(htmlDoc, config, subject.value) : combineBodyWithJitsiDiv(result.value, config, subject.value);
+        setData(bodyDOM, event);
+      });
     } catch (error) {
       // If it fails to manipulate the DOM with a new link it will fallback to its original state
       setData(result.value, event);

--- a/src/utils/DOMHelper.ts
+++ b/src/utils/DOMHelper.ts
@@ -9,8 +9,8 @@ import { getJitsiUrl } from "./URLHelper";
 
 const DIV_ID_JITSI = "jitsi-link";
 
-export const combineBodyWithJitsiDiv = (body: string, config: Config): string => {
-  const jitsiUrl = getJitsiUrl(config);
+export const combineBodyWithJitsiDiv = (body: string, config: Config, subject: string): string => {
+  const jitsiUrl = getJitsiUrl(config, subject);
 
   const linkDOM = getJitsiLinkDiv(jitsiUrl, config);
   const parser = new DOMParser();
@@ -31,8 +31,8 @@ export const bodyHasJitsiLink = (body: string, config: Config): boolean => {
   return urlRegex.test(body);
 };
 
-export const overwriteJitsiLinkDiv = (body: Document, config: Config): string => {
-  const jitsiUrl = getJitsiUrl(config);
+export const overwriteJitsiLinkDiv = (body: Document, config: Config, subject?: string): string => {
+  const jitsiUrl = getJitsiUrl(config, subject);
 
   const jitsiLink = body.querySelector(`[id*="${DIV_ID_JITSI}"]`);
   const newJitsiLink = getJitsiLinkDiv(jitsiUrl, config);

--- a/src/utils/URLHelper.ts
+++ b/src/utils/URLHelper.ts
@@ -26,6 +26,30 @@ export const getConfigUrl = (config: Config): string => {
   return url;
 };
 
-export const getJitsiUrl = (config: Config): string => {
-  return (config.baseUrl ?? defaultMeetJitsiUrl) + getRandomRoomName() + getConfigUrl(config);
+export const secureSubjectUrl = (string: string, length?: number): string => {
+  if (length === undefined) {
+    length = 30;
+  }
+  let subject: string = string;
+  subject = subject.replace(/[áàäâãåÁÀÄÂÃÅ]/g, "a");
+  subject = subject.replace(/[óòöôõÓÒÖÔÕ]/g, "o");
+  subject = subject.replace(/[éèëêÉÈËÊ]/g, "e");
+  subject = subject.replace(/[úùüûÚÙÜÛ]/g, "u");
+  subject = subject.replace(/[íìïîÍÌÏÎ]/g, "i");
+  subject = subject.replace(/[^A-Za-z0-9]/g, "-");
+  subject = subject.replace(/--+/g, "-");
+  subject = subject.slice(0, length);
+  if (subject.length <= 1) {
+    subject = "";
+  } else {
+    subject = subject + "_";
+  }
+  return subject;
+};
+
+export const getJitsiUrl = (config: Config, subject?: string): string => {
+  if (subject !== undefined) {
+    subject = secureSubjectUrl(subject);
+  }
+  return (config.baseUrl ?? defaultMeetJitsiUrl) + subject + getRandomRoomName() + getConfigUrl(config);
 };


### PR DESCRIPTION
# Pull Request Description

I have added a call to the subject row of the composed meeting. The commit handles empty subject, character removal and cleaning of the subject row. It will automatically remove åäö ÅÄÖ or any other special characters not used in URI and replace with the URI alternative, i.e Ö becomes O and Å becomes A and so on. Link will look something like this:
Mote-angaende-nasta-sprint if the original was Möte angående nästa sprint.
Random string will be added at the end to eliminate collisions. 

Fixes #45

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [X] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
