### PR TITLE
Added html header to fetch Msonormal styles from Office document

### DIFF
--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -34,7 +34,7 @@ const addJitsiLink = (event: Office.AddinCommands.Event) => {
       const parser = new DOMParser();
       const htmlDoc = parser.parseFromString(result.value, "text/html");
       const bodyDOM = bodyHasJitsiLink(result.value, config) ? overwriteJitsiLinkDiv(htmlDoc, config) : combineBodyWithJitsiDiv(result.value, config);
-      setData(bodyDOM, event);
+      setData(htmlDoc.head.innerHTML + bodyDOM, event);
     } catch (error) {
       // If it fails to manipulate the DOM with a new link it will fallback to its original state
       setData(result.value, event);


### PR DESCRIPTION
# Pull Request Description

This change will help Outlook client to recreate the message after the link is added in the bottom of the body.
For more explanation and links see my answer to this stackoverflow: https://stackoverflow.com/questions/51603265/line-spacing-increased-issue-when-updating-email-body-with-office-js/78542353#78542353

Fixes #31 

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
